### PR TITLE
hotfix(debug): removed debug for mouse position

### DIFF
--- a/game/menu.py
+++ b/game/menu.py
@@ -96,9 +96,7 @@ class Menu:
         for event in pygame.event.get():
             if event.type == pygame.MOUSEMOTION:
                 cls.mx, cls.my = pygame.mouse.get_pos()
-                print((cls.mx, cls.my))
             if event.type == pygame.MOUSEBUTTONDOWN:
-                print((cls.mx, cls.my))
                 if pygame.Rect.collidepoint(cls.play_button_rect,
                                             (cls.mx, cls.my)):
                     pass


### PR DESCRIPTION
[Description]:
Debug mouse position was added to the terminal as a console output, however this was only needed when testing the buttons and was not removed (when it should have been) when the development branch was merged into the main branch.

[Related Issues/PRs]:
ref: #8

[Tags/Labels]:
bug
hotfix