### PR TITLE
actions(docs): bump python version

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - './docs/**'
       
 jobs:
   publish_docs:
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.11"
       
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This commit bumps the python version from 3.9 to "3.11". 
> quotation marks are included as this is a requirement for YAML >= 3.10